### PR TITLE
Machines shouldn't drain power without making progress.

### DIFF
--- a/src/main/java/net/silentchaos512/mechanisms/block/AbstractFluidMachineTileEntity.java
+++ b/src/main/java/net/silentchaos512/mechanisms/block/AbstractFluidMachineTileEntity.java
@@ -135,18 +135,18 @@ public abstract class AbstractFluidMachineTileEntity<R extends IFluidRecipe<?>> 
                 getFluidResults(recipe).forEach(this::storeResultFluid);
                 getProcessResults(recipe).forEach(this::storeResultItem);
                 consumeFeedstock(recipe);
+                progress = 0;
 
                 if (getRecipe() == null) {
-                    // Nothing left to process
                     setInactiveState();
-                } else {
-                    // Continue processing next output
-                    progress = 0;
                 }
             } else {
                 sendUpdate(getActiveState(world.getBlockState(pos)));
             }
         } else {
+            if (recipe == null) {
+                progress = 0;
+            }
             setInactiveState();
         }
     }

--- a/src/main/java/net/silentchaos512/mechanisms/block/AbstractMachineTileEntity.java
+++ b/src/main/java/net/silentchaos512/mechanisms/block/AbstractMachineTileEntity.java
@@ -164,7 +164,6 @@ public abstract class AbstractMachineTileEntity<R extends IRecipe<?>> extends Ab
 
     protected void setInactiveState() {
         if (world == null) return;
-        progress = 0;
         sendUpdate(getInactiveState(world.getBlockState(pos)));
     }
 
@@ -183,18 +182,18 @@ public abstract class AbstractMachineTileEntity<R extends IRecipe<?>> extends Ab
                 // Create result
                 getProcessResults(recipe).forEach(this::storeResultItem);
                 consumeIngredients(recipe);
+                progress = 0;
 
                 if (getRecipe() == null) {
-                    // Nothing left to process
                     setInactiveState();
-                } else {
-                    // Continue processing next output
-                    progress = 0;
                 }
             } else {
                 sendUpdate(getActiveState(world.getBlockState(pos)));
             }
         } else {
+            if (recipe == null) {
+                progress = 0;
+            }
             setInactiveState();
         }
     }


### PR DESCRIPTION
Small change to pause progress when a machine loses power, rather than resetting it, otherwise machines may end up constantly draining power if they are receiving enough to tick the machine but not enough to complete the recipe.

Instead, progress is reset whenever any recipe is completed or whenever the recipe is null, but the machine becoming inactive for any other reason (power, redstone, etc.) will just paused it, rather than resetting progress to zero.